### PR TITLE
ニックネーム機能を規模縮小した上で再実装する #29

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -27,6 +27,11 @@
       <option name="url" value="https://repo.opencollab.dev/maven-snapshots/" />
     </remote-repository>
     <remote-repository>
+      <option name="id" value="Scarsz-Nexus" />
+      <option name="name" value="Scarsz-Nexus" />
+      <option name="url" value="https://nexus.scarsz.me/content/groups/public/" />
+    </remote-repository>
+    <remote-repository>
       <option name="id" value="central" />
       <option name="name" value="Maven Central repository" />
       <option name="url" value="https://repo1.maven.org/maven2" />

--- a/XelticaMCOtanoshimiPlugin.iml
+++ b/XelticaMCOtanoshimiPlugin.iml
@@ -123,7 +123,6 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.steveice10:opennbt:1.4" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.GeyserMC:PacketLib:0b75570" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.spotbugs:spotbugs-annotations:4.2.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.findbugs:jsr305:3.0.2" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: io.netty:netty-resolver-dns:4.1.59.Final" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: io.netty:netty-common:4.1.59.Final" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: io.netty:netty-buffer:4.1.59.Final" level="project" />
@@ -167,5 +166,38 @@
     <orderEntry type="library" name="Maven: com.gilecode.yagson:j9-reflection-utils:1.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: de.tr7zw:item-nbt-api-plugin:2.8.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.20" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.discordsrv:discordsrv:1.21.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.dv8tion:JDA:4.2.0_222" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.findbugs:jsr305:3.0.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.squareup.okhttp3:okhttp:3.13.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.squareup.okio:okio:1.17.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.commons:commons-collections4:4.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.neovisionaries:nv-websocket-client:2.10" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.trove4j:trove4j:3.0.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: github.scarsz:configuralize:1.3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-jdk14:1.7.25" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-io:commons-io:2.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-collections:commons-collections:3.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.commons:commons-lang3:3.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-codec:commons-codec:1.11" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.vdurmont:emoji-java:3.1.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.json:json:20140107" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.zafarkhaja:java-semver:0.9.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.kevinsawicki:http-request:6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.minidns:minidns-hla:0.3.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.minidns:minidns-dnssec:0.3.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.minidns:minidns-client:0.3.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.minidns:minidns-core:0.3.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.minidns:minidns-iterative-resolver:0.3.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-expression:5.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-core:5.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-jcl:5.2.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: dev.vankka:MCDiscordReserializer:3.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: dev.vankka:SimpleAST:2.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:text-api:3.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:text-serializer-legacy:3.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:text-adapter-bukkit:3.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:text-serializer-gson:3.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.14-R0.1-SNAPSHOT" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
       <id>opencollab-snapshot-repo</id>
       <url>https://repo.opencollab.dev/maven-snapshots/</url>
     </repository>
+
+    <repository>
+      <id>Scarsz-Nexus</id>
+      <url>https://nexus.scarsz.me/content/groups/public/</url>
+    </repository>
   </repositories>
 
   <dependencies>
@@ -92,6 +97,13 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.20</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.discordsrv</groupId>
+      <artifactId>discordsrv</artifactId>
+      <version>1.21.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/work/xeltica/craft/core/XCorePlugin.java
+++ b/src/main/java/work/xeltica/craft/core/XCorePlugin.java
@@ -23,6 +23,7 @@ import work.xeltica.craft.core.commands.CommandHint;
 import work.xeltica.craft.core.commands.CommandHub;
 import work.xeltica.craft.core.commands.CommandLive;
 import work.xeltica.craft.core.commands.CommandLocalTime;
+import work.xeltica.craft.core.commands.CommandNickName;
 import work.xeltica.craft.core.commands.CommandOmikuji;
 import work.xeltica.craft.core.commands.CommandXCoreGuiEvent;
 import work.xeltica.craft.core.commands.CommandXPhone;
@@ -197,6 +198,7 @@ public class XCorePlugin extends JavaPlugin {
         commands.put("__core_gui_event__", new CommandXCoreGuiEvent());
         commands.put("xphone", new CommandXPhone());
         commands.put("live", new CommandLive());
+        commands.put("nick", new CommandNickName());
     }
 
     private void loadHandlers() {

--- a/src/main/java/work/xeltica/craft/core/XCorePlugin.java
+++ b/src/main/java/work/xeltica/craft/core/XCorePlugin.java
@@ -51,6 +51,7 @@ import work.xeltica.craft.core.runnables.NightmareRandomEvent;
 import work.xeltica.craft.core.stores.HubStore;
 import work.xeltica.craft.core.stores.ItemStore;
 import work.xeltica.craft.core.stores.MetaStore;
+import work.xeltica.craft.core.stores.NickNameStore;
 import work.xeltica.craft.core.stores.OmikujiStore;
 import work.xeltica.craft.core.stores.PlayerStore;
 import work.xeltica.craft.core.stores.VehicleStore;
@@ -171,6 +172,7 @@ public class XCorePlugin extends JavaPlugin {
         new HintStore();
         new MetaStore();
         new BossBarStore();
+        new NickNameStore();
     }
 
     private void loadCommands() {

--- a/src/main/java/work/xeltica/craft/core/commands/CommandNickName.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandNickName.java
@@ -1,0 +1,44 @@
+package work.xeltica.craft.core.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import work.xeltica.craft.core.XCorePlugin;
+import work.xeltica.craft.core.stores.NickNameStore;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author raink1208
+ */
+public class CommandNickName extends CommandPlayerOnlyBase implements TabCompleter {
+    public CommandNickName() {
+        final var command = XCorePlugin.getInstance().getCommand("nick");
+        if (command != null) {
+            command.setTabCompleter(this);
+        }
+    }
+
+    @Override
+    public boolean execute(Player player, Command command, String label, String[] args) {
+        if (args.length == 0) return false;
+
+        NickNameStore.getInstance().setNickNameType(player.getUniqueId(), args[0]);
+        NickNameStore.getInstance().setNickName(player);
+
+        player.sendMessage("NickNameTypeを" + args[0] + "に変更しました");
+        return true;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
+        return COMMANDS;
+    }
+
+    private static final List<String> COMMANDS = new ArrayList<>(Arrays.asList("minecraft", "discord", "discord-nick"));
+}

--- a/src/main/java/work/xeltica/craft/core/commands/CommandNickName.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandNickName.java
@@ -29,9 +29,8 @@ public class CommandNickName extends CommandPlayerOnlyBase implements TabComplet
         if (args.length == 0) return false;
 
         NickNameStore.getInstance().setNickNameType(player.getUniqueId(), args[0]);
-        NickNameStore.getInstance().setNickName(player);
-
         player.sendMessage("NickNameTypeを" + args[0] + "に変更しました");
+        NickNameStore.getInstance().setNickName(player);
         return true;
     }
 

--- a/src/main/java/work/xeltica/craft/core/handlers/PlayerHandler.java
+++ b/src/main/java/work/xeltica/craft/core/handlers/PlayerHandler.java
@@ -50,6 +50,7 @@ import work.xeltica.craft.core.stores.BossBarStore;
 import work.xeltica.craft.core.stores.HintStore;
 import work.xeltica.craft.core.stores.HubStore;
 import work.xeltica.craft.core.stores.ItemStore;
+import work.xeltica.craft.core.stores.NickNameStore;
 import work.xeltica.craft.core.stores.OmikujiStore;
 import work.xeltica.craft.core.stores.PlayerStore;
 import work.xeltica.craft.core.utils.BedrockDisclaimerUtil;
@@ -99,6 +100,9 @@ public class PlayerHandler implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent e) {
         final var p = e.getPlayer();
+
+        NickNameStore.getInstance().setNickName(p);
+
         final var name = PlainTextComponentSerializer.plainText().serialize(p.displayName());
         final var pstore = PlayerStore.getInstance();
         e.joinMessage(Component.text("§a" + name + "§b" + "さんがやってきました"));

--- a/src/main/java/work/xeltica/craft/core/stores/NickNameStore.java
+++ b/src/main/java/work/xeltica/craft/core/stores/NickNameStore.java
@@ -1,0 +1,74 @@
+package work.xeltica.craft.core.stores;
+
+import github.scarsz.discordsrv.DiscordSRV;
+import github.scarsz.discordsrv.dependencies.jda.api.entities.Member;
+import net.luckperms.api.LuckPerms;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import work.xeltica.craft.core.utils.Config;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * @author raink1208
+ */
+public class NickNameStore {
+    public NickNameStore() {
+        instance = this;
+        config = new Config("nickname");
+    }
+
+    public static NickNameStore getInstance() { return instance; }
+
+    public String getNickName(UUID uuid, String type) {
+        return switch (type) {
+            case "discord" -> getDiscordMember(uuid).getUser().getName();
+            case "discord-nick" -> getDiscordMember(uuid).getNickname();
+            default -> Objects.requireNonNull(Bukkit.getPlayer(uuid)).getName();
+        };
+    }
+
+    public void setNickName(Player player) {
+        final var provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+        final var luckPerms = provider.getProvider();
+        final var ctx = luckPerms.getContextManager().getContext(player);
+        String type = getNickNameType(player.getUniqueId());
+
+        if (!ctx.contains("discordsrv:linked", "true")) {
+            type = "minecraft";
+        }
+
+        final String nickname = getNickName(player.getUniqueId(), type);
+
+        player.setCustomName(nickname);
+        player.setPlayerListName(nickname);
+        player.setDisplayName(nickname);
+    }
+
+    public String getNickNameType(UUID uuid) {
+        final var type = config.getConf().get(uuid.toString());
+        if (type instanceof String) {
+            return (String) type;
+        }
+        return "null";
+    }
+
+    public void setNickNameType(UUID uuid, String type) {
+        config.getConf().set(uuid.toString(), type);
+        try {
+            config.save();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public Member getDiscordMember(UUID uuid) {
+        final String discordId = DiscordSRV.getPlugin().getAccountLinkManager().getDiscordId(uuid);
+        return DiscordSRV.getPlugin().getMainGuild().getMemberById(discordId);
+    }
+
+    private static NickNameStore instance;
+    private final Config config;
+}

--- a/src/main/java/work/xeltica/craft/core/stores/NickNameStore.java
+++ b/src/main/java/work/xeltica/craft/core/stores/NickNameStore.java
@@ -42,6 +42,11 @@ public class NickNameStore {
 
         final String nickname = getNickName(player.getUniqueId(), type);
 
+        if (nicknameLength(nickname) > nicknameLimit) {
+            player.sendMessage("nicknameの長さが " + nicknameLimit + "文字 より長いので変更できませんでした");
+            return;
+        }
+
         player.setCustomName(nickname);
         player.setPlayerListName(nickname);
         player.setDisplayName(nickname);
@@ -69,6 +74,20 @@ public class NickNameStore {
         return DiscordSRV.getPlugin().getMainGuild().getMemberById(discordId);
     }
 
+    private Integer nicknameLength(String nickname) {
+        double length = 0.0;
+        for (Character c: nickname.toCharArray()) {
+            if (String.valueOf(c).getBytes().length < 2) {
+                length += 0.5;
+            } else {
+                length += 1;
+            }
+        }
+        return (int) Math.ceil(length);
+    }
+
     private static NickNameStore instance;
     private final Config config;
+
+    private final Integer nicknameLimit = 8;
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -82,6 +82,10 @@ commands:
     description: ヒントメニューを開きます。
     usage: /hint [hint-id]
     permission: otanoshimi.command.hint
+  nick:
+    description: ニックネームを変更
+    usage: /nick [minecraft|discord|discord-nick]
+    permission: otanosimi.command.nickname
   __core_gui_event__:
     description: "?"
     usage: "?"
@@ -136,3 +140,5 @@ permissions:
     defualt: true
   otanoshimi.command.live:
     defualt: true
+  otanosimmi.command.nickname:
+    default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ depend:
   - Geyser-Spigot
   - Vault
   - floodgate
+  - DiscordSRV
 commands:
   omikuji:
     description: おみくじを引きます。マイクラ内で1日に1回まで引けて、100エビパワーを消費します。


### PR DESCRIPTION
ニックネームの変更(/nick <minecraft/discord/discord-nick>)
ニックネームの文字数を全角換算で8文字に

new feature #29 