### PR TITLE
プレイヤーデータの引っ越し[修正]

### DIFF
--- a/src/main/java/work/xeltica/craft/core/handlers/XphoneHandler.java
+++ b/src/main/java/work/xeltica/craft/core/handlers/XphoneHandler.java
@@ -228,6 +228,7 @@ public class XphoneHandler implements Listener {
 
         for (Player p: player.getServer().getOnlinePlayers()) {
             if (p.getUniqueId() == player.getUniqueId()) continue;
+            if (TransferPlayerData.getInstance(p) != null) continue;
             list.add(new MenuItem(p.getName(), i -> new TransferPlayerData(player, p)));
         }
         ui().openMenu(player, "引っ越し先の選択", list);

--- a/src/main/java/work/xeltica/craft/core/handlers/XphoneHandler.java
+++ b/src/main/java/work/xeltica/craft/core/handlers/XphoneHandler.java
@@ -213,6 +213,7 @@ public class XphoneHandler implements Listener {
                 items.add(new MenuItem("引っ越しキャンセル", i -> cancelTransferPlayerData(player), Material.CHEST_MINECART, null, true));
             } else if (transferPlayerData.getType(player) == TransferPlayerData.TransferPlayerType.TO_PLAYER) {
                 items.add(new MenuItem("引っ越しを受け入れる", i -> acceptTransferPlayerData(player), Material.CHEST_MINECART, null, true));
+                items.add(new MenuItem("引っ越しを受け入れない", i -> cancelTransferPlayerData(player), Material.CHEST_MINECART, null, true));
             }
         } else {
             items.add(new MenuItem("引っ越し", i -> openTransferPlayerDataApp(player), Material.CHEST_MINECART));

--- a/src/main/java/work/xeltica/craft/core/models/TransferPlayerData.java
+++ b/src/main/java/work/xeltica/craft/core/models/TransferPlayerData.java
@@ -76,7 +76,7 @@ public class TransferPlayerData {
         for (String hintName: hintStore.getArchived(from)) {
             for (Hint hint: Hint.values()) {
                 if (hint.getName().equals(hintName)) {
-                    hintStore.achieve(to, hint);
+                    hintStore.achieve(to, hint, false);
                     break;
                 }
             }

--- a/src/main/java/work/xeltica/craft/core/stores/HintStore.java
+++ b/src/main/java/work/xeltica/craft/core/stores/HintStore.java
@@ -46,6 +46,22 @@ public class HintStore {
         return open(p).contains(hint.name());
     }
 
+    public void achieve(Player p, Hint hint, boolean reward) {
+        if (reward) {
+            achieve(p, hint);
+            return;
+        }
+        if (hasAchieved(p, hint)) return;
+        final var list = open(p);
+        list.add(hint.name());
+        hints.getConf().set(p.getUniqueId().toString(), list);
+        try {
+            save();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
     public void achieve(Player p, Hint hint) {
         if (hasAchieved(p, hint)) return;
         final var list = open(p);


### PR DESCRIPTION
引っ越し受け入れ側で拒否できるように
Hintのリワードを受け取らない
先に引っ越し先に指定されてた場合引っ越し相手に指定できないように