### PR TITLE
モジュール化

### DIFF
--- a/src/main/java/work/xeltica/craft/core/api/ModuleBase.kt
+++ b/src/main/java/work/xeltica/craft/core/api/ModuleBase.kt
@@ -1,0 +1,30 @@
+package work.xeltica.craft.core.api
+
+import org.bukkit.Bukkit
+import org.bukkit.event.Listener
+import work.xeltica.craft.core.XCorePlugin
+import work.xeltica.craft.core.api.commands.CommandBase
+import work.xeltica.craft.core.api.commands.CommandRegistry
+import work.xeltica.craft.core.modules.xphone.XphoneModule
+import work.xeltica.craft.core.xphone.apps.AppBase
+
+/**
+ * モジュールの基底クラス。
+ */
+abstract class ModuleBase {
+    open fun onEnable() {}
+    open fun onPostEnable() {}
+    open fun onDisable() {}
+
+    protected fun registerCommand(name: String, command: CommandBase) {
+        CommandRegistry.register(name, command)
+    }
+
+    protected fun registerHandler(handler: Listener) {
+        Bukkit.getPluginManager().registerEvents(handler, XCorePlugin.instance)
+    }
+
+    protected fun registerXPhoneApp(app: AppBase) {
+        XphoneModule.registerApp(app)
+    }
+}

--- a/src/main/java/work/xeltica/craft/core/api/commands/CommandBase.java
+++ b/src/main/java/work/xeltica/craft/core/api/commands/CommandBase.java
@@ -1,4 +1,4 @@
-package work.xeltica.craft.core.commands;
+package work.xeltica.craft.core.api.commands;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/work/xeltica/craft/core/api/commands/CommandPlayerOnlyBase.java
+++ b/src/main/java/work/xeltica/craft/core/api/commands/CommandPlayerOnlyBase.java
@@ -1,9 +1,10 @@
-package work.xeltica.craft.core.commands;
+package work.xeltica.craft.core.api.commands;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import work.xeltica.craft.core.api.commands.CommandBase;
 
 /**
  * プレイヤー限定のコマンドの基底クラス

--- a/src/main/java/work/xeltica/craft/core/api/commands/CommandRegistry.kt
+++ b/src/main/java/work/xeltica/craft/core/api/commands/CommandRegistry.kt
@@ -1,0 +1,39 @@
+package work.xeltica.craft.core.api.commands
+
+import org.bukkit.Bukkit
+import org.bukkit.command.Command
+import org.bukkit.command.CommandExecutor
+import org.bukkit.command.CommandSender
+import java.util.*
+import kotlin.collections.HashMap
+
+object CommandRegistry : CommandExecutor {
+    fun register(name: String, command: CommandBase) {
+        val logger = Bukkit.getLogger()
+        if (commandsMap.containsKey(name)) {
+            logger.warning("コマンド '${name}' は既に登録されているため、スキップします。")
+            return
+        }
+        val cmd = Bukkit.getPluginCommand(name)
+        if (cmd == null) {
+            logger.warning("コマンド '$name' は plugin.yml で定義されていないため、スキップします。")
+            return
+        }
+        cmd.setExecutor(this)
+        cmd.tabCompleter = command
+        commandsMap[name] = command
+        logger.info("コマンド '$name' を登録しました。")
+    }
+
+    fun clearMap() {
+        commandsMap.clear()
+    }
+
+    override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
+        val name = command.name.lowercase(Locale.getDefault())
+        val com = commandsMap[name] ?: return false
+        return com.execute(sender, command, label, args)
+    }
+
+    private val commandsMap = HashMap<String, CommandBase>()
+}

--- a/src/main/java/work/xeltica/craft/core/commands/CommandBoat.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandBoat.java
@@ -16,6 +16,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.gui.Gui;
 import work.xeltica.craft.core.models.Hint;
 import work.xeltica.craft.core.stores.HintStore;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandCart.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandCart.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.jetbrains.annotations.NotNull;
 
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.gui.Gui;
 import work.xeltica.craft.core.models.Hint;
 import work.xeltica.craft.core.stores.HintStore;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandCat.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandCat.java
@@ -8,6 +8,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.gui.Gui;
 import work.xeltica.craft.core.models.Hint;
 import work.xeltica.craft.core.models.PlayerDataKey;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandCountdown.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandCountdown.java
@@ -20,6 +20,7 @@ import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import work.xeltica.craft.core.XCorePlugin;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.models.Hint;
 import work.xeltica.craft.core.stores.HintStore;
 import work.xeltica.craft.core.utils.Ticks;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandCounter.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandCounter.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.gui.Gui;
 import work.xeltica.craft.core.models.CounterData;
 import work.xeltica.craft.core.models.PlayerDataKey;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandEpEffectShop.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandEpEffectShop.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -22,6 +21,7 @@ import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import work.xeltica.craft.core.XCorePlugin;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.gui.Gui;
 import work.xeltica.craft.core.gui.MenuItem;
 import work.xeltica.craft.core.models.EbiPowerEffect;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandEpShop.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandEpShop.java
@@ -21,6 +21,7 @@ import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import work.xeltica.craft.core.XCorePlugin;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.gui.Gui;
 import work.xeltica.craft.core.gui.MenuItem;
 import work.xeltica.craft.core.models.EbiPowerItem;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandGiveCustomItem.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandGiveCustomItem.java
@@ -8,6 +8,7 @@ import org.bukkit.command.Command;
 import org.bukkit.entity.Player;
 
 import net.kyori.adventure.text.Component;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.stores.ItemStore;
 
 import java.util.Objects;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandGiveMobBall.kt
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandGiveMobBall.kt
@@ -6,6 +6,7 @@ import org.bukkit.Sound
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase
 import work.xeltica.craft.core.stores.MobBallStore
 
 class CommandGiveMobBall : CommandPlayerOnlyBase() {

--- a/src/main/java/work/xeltica/craft/core/commands/CommandHint.kt
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandHint.kt
@@ -4,6 +4,7 @@ import org.bukkit.Material
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase
 import work.xeltica.craft.core.stores.HintStore.Companion.instance
 import work.xeltica.craft.core.gui.Gui
 import work.xeltica.craft.core.gui.MenuItem

--- a/src/main/java/work/xeltica/craft/core/commands/CommandHub.kt
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandHub.kt
@@ -3,6 +3,7 @@ package work.xeltica.craft.core.commands
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase
 import work.xeltica.craft.core.stores.HubStore
 import work.xeltica.craft.core.models.HubType
 

--- a/src/main/java/work/xeltica/craft/core/commands/CommandLive.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandLive.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import org.jetbrains.annotations.Nullable;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.gui.Gui;
 import work.xeltica.craft.core.stores.PlayerStore;
 

--- a/src/main/java/work/xeltica/craft/core/commands/CommandLocalTime.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandLocalTime.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 
 /**
  * 現在いるワールドのみの時間を操作するコマンド

--- a/src/main/java/work/xeltica/craft/core/commands/CommandNickName.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandNickName.java
@@ -2,12 +2,11 @@ package work.xeltica.craft.core.commands;
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import work.xeltica.craft.core.XCorePlugin;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.stores.NickNameStore;
 
 import java.util.ArrayList;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandOmikuji.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandOmikuji.java
@@ -13,6 +13,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import work.xeltica.craft.core.XCorePlugin;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.models.Hint;
 import work.xeltica.craft.core.plugins.VaultPlugin;
 import work.xeltica.craft.core.stores.HintStore;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandPromo.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandPromo.java
@@ -1,7 +1,6 @@
 package work.xeltica.craft.core.commands;
 
 import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -10,6 +9,7 @@ import net.luckperms.api.LuckPerms;
 import net.luckperms.api.query.QueryOptions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.models.PlayerDataKey;
 import work.xeltica.craft.core.stores.PlayerStore;
 import work.xeltica.craft.core.utils.Ticks;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandPvp.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandPvp.java
@@ -7,6 +7,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 
 /**
  * PvPの有効・無効を切り替えるコマンド

--- a/src/main/java/work/xeltica/craft/core/commands/CommandQuickChat.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandQuickChat.java
@@ -5,6 +5,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import work.xeltica.craft.core.api.commands.CommandBase;
 import work.xeltica.craft.core.stores.QuickChatStore;
 
 import java.util.ArrayList;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandRanking.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandRanking.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import work.xeltica.craft.core.api.commands.CommandBase;
 import work.xeltica.craft.core.models.Ranking;
 import work.xeltica.craft.core.stores.RankingStore;
 

--- a/src/main/java/work/xeltica/craft/core/commands/CommandReport.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandReport.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.command.Command;
@@ -18,6 +17,7 @@ import org.bukkit.potion.PotionEffectType;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.gui.Gui;
 import work.xeltica.craft.core.gui.MenuItem;
 import work.xeltica.craft.core.utils.DiscordService;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandRespawn.kt
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandRespawn.kt
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player
 import org.bukkit.event.player.PlayerTeleportEvent
 import org.bukkit.scheduler.BukkitRunnable
 import work.xeltica.craft.core.XCorePlugin.Companion.instance
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase
 import work.xeltica.craft.core.stores.WorldStore
 import java.util.UUID
 import java.util.HashMap

--- a/src/main/java/work/xeltica/craft/core/commands/CommandSignEdit.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandSignEdit.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 
 /**
  * 看板を編集するコマンド

--- a/src/main/java/work/xeltica/craft/core/commands/CommandStamp.kt
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandStamp.kt
@@ -2,6 +2,7 @@ package work.xeltica.craft.core.commands
 
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
+import work.xeltica.craft.core.api.commands.CommandBase
 import work.xeltica.craft.core.stores.StampRallyStore
 
 class CommandStamp: CommandBase() {

--- a/src/main/java/work/xeltica/craft/core/commands/CommandXCoreGuiEvent.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandXCoreGuiEvent.java
@@ -3,6 +3,7 @@ package work.xeltica.craft.core.commands;
 import org.bukkit.command.Command;
 import org.bukkit.entity.Player;
 
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.gui.Gui;
 
 /**

--- a/src/main/java/work/xeltica/craft/core/commands/CommandXDebug.kt
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandXDebug.kt
@@ -2,7 +2,7 @@ package work.xeltica.craft.core.commands
 
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
-import org.bukkit.entity.Player
+import work.xeltica.craft.core.api.commands.CommandBase
 import work.xeltica.craft.core.utils.EventUtility
 import java.time.LocalDate
 

--- a/src/main/java/work/xeltica/craft/core/commands/CommandXReload.kt
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandXReload.kt
@@ -2,6 +2,7 @@ package work.xeltica.craft.core.commands
 
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
+import work.xeltica.craft.core.api.commands.CommandBase
 import work.xeltica.craft.core.stores.MobBallStore
 import work.xeltica.craft.core.stores.NotificationStore
 

--- a/src/main/java/work/xeltica/craft/core/commands/CommandXtp.java
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandXtp.java
@@ -10,6 +10,7 @@ import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import work.xeltica.craft.core.XCorePlugin;
+import work.xeltica.craft.core.api.commands.CommandBase;
 import work.xeltica.craft.core.stores.WorldStore;
 
 import java.util.ArrayList;

--- a/src/main/java/work/xeltica/craft/core/commands/CommandXtpReset.kt
+++ b/src/main/java/work/xeltica/craft/core/commands/CommandXtpReset.kt
@@ -6,6 +6,7 @@ import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 import org.bukkit.util.StringUtil
 import work.xeltica.craft.core.XCorePlugin
+import work.xeltica.craft.core.api.commands.CommandBase
 import work.xeltica.craft.core.stores.WorldStore
 import java.util.*
 

--- a/src/main/java/work/xeltica/craft/core/modules/xphone/XphoneCommand.java
+++ b/src/main/java/work/xeltica/craft/core/modules/xphone/XphoneCommand.java
@@ -1,4 +1,4 @@
-package work.xeltica.craft.core.commands;
+package work.xeltica.craft.core.modules.xphone;
 
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import work.xeltica.craft.core.api.commands.CommandPlayerOnlyBase;
 import work.xeltica.craft.core.models.Hint;
 import work.xeltica.craft.core.stores.HintStore;
 import work.xeltica.craft.core.stores.ItemStore;
@@ -20,7 +21,7 @@ import java.util.Objects;
  * X Phoneを受け取るコマンド
  * @author Xeltica
  */
-public class CommandXPhone extends CommandPlayerOnlyBase {
+public class XphoneCommand extends CommandPlayerOnlyBase {
     @Override
     public boolean execute(Player player, Command command, String label, String[] args) {
         final var item = ItemStore.getInstance().getItem("xphone");

--- a/src/main/java/work/xeltica/craft/core/modules/xphone/XphoneHandler.kt
+++ b/src/main/java/work/xeltica/craft/core/modules/xphone/XphoneHandler.kt
@@ -1,4 +1,4 @@
-package work.xeltica.craft.core.handlers
+package work.xeltica.craft.core.modules.xphone
 
 import org.bukkit.event.Event
 import org.bukkit.event.EventHandler
@@ -8,7 +8,6 @@ import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.inventory.EquipmentSlot
 import work.xeltica.craft.core.stores.ItemStore
-import work.xeltica.craft.core.xphone.XphoneOs
 
 /**
  * X Phoneに関する機能をまとめています。
@@ -29,7 +28,7 @@ class XphoneHandler : Listener {
         if (!listOf(Action.RIGHT_CLICK_AIR, Action.RIGHT_CLICK_BLOCK).contains(e.action)) return
         e.setUseItemInHand(Event.Result.DENY)
 
-        XphoneOs.openSpringBoard(player)
+        XphoneModule.openSpringBoard(player)
     }
 
     @EventHandler(priority = EventPriority.HIGH)

--- a/src/main/java/work/xeltica/craft/core/modules/xphone/XphoneModule.kt
+++ b/src/main/java/work/xeltica/craft/core/modules/xphone/XphoneModule.kt
@@ -1,24 +1,25 @@
-package work.xeltica.craft.core.xphone
+package work.xeltica.craft.core.modules.xphone
 
+import org.bukkit.Bukkit
 import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.geysermc.floodgate.api.FloodgateApi
+import work.xeltica.craft.core.api.ModuleBase
 import work.xeltica.craft.core.gui.Gui
 import work.xeltica.craft.core.gui.MenuItem
 import work.xeltica.craft.core.models.SoundPitch
 import work.xeltica.craft.core.stores.ItemStore
 import work.xeltica.craft.core.xphone.apps.*
 import java.lang.IllegalStateException
-import java.time.LocalDate
 
 /**
  * X Phone の基幹となるシステムです。
  */
-object XphoneOs {
+object XphoneModule : ModuleBase() {
     /**
      * X-Core が有効になったときに呼ばれます。
      */
-    fun onEnabled() {
+    override fun onEnable() {
         apps.addAll(listOf(
             EventRespawnApp(),
             EventReturnWorldApp(),
@@ -44,13 +45,26 @@ object XphoneOs {
             PunishApp(),
             StampRallyApp(),
         ))
+
+        registerCommand("xphone", XphoneCommand())
+        registerHandler(XphoneHandler())
     }
 
     /**
      * X-Core が無効になったときに呼ばれます。
      */
-    fun onDisabled() {
+    override fun onDisable() {
         apps.clear()
+    }
+
+    /**
+     * X Phone にアプリを登録します。
+     */
+    fun registerApp(app: AppBase) {
+        if (apps.contains(app)) {
+            Bukkit.getLogger().warning("X Phoneアプリ「${app.javaClass.name}」は既に登録されているため、無視します。")
+        }
+        apps.add(app)
     }
 
     /**
@@ -93,7 +107,7 @@ object XphoneOs {
         ui().playSoundLocallyAfter(player, Sound.BLOCK_NOTE_BLOCK_IRON_XYLOPHONE, 1f, SoundPitch.D2, 4)
     }
 
-    const val name = "X Phone OS 2.2"
+    const val name = "X Phone OS 3.0"
 
     private val apps = mutableListOf<AppBase>()
 }

--- a/src/main/java/work/xeltica/craft/core/stores/NotificationStore.kt
+++ b/src/main/java/work/xeltica/craft/core/stores/NotificationStore.kt
@@ -11,7 +11,7 @@ import org.json.simple.parser.JSONParser
 import work.xeltica.craft.core.XCorePlugin
 import work.xeltica.craft.core.models.Notification
 import work.xeltica.craft.core.utils.Config
-import work.xeltica.craft.core.xphone.XphoneOs
+import work.xeltica.craft.core.modules.xphone.XphoneModule
 import java.io.File
 import java.io.FileReader
 import java.util.UUID
@@ -93,7 +93,7 @@ class NotificationStore {
             player.sendMessage("${ChatColor.GREEN}・${ChatColor.RESET}${it.title}")
         }
         player.sendMessage("${ChatColor.LIGHT_PURPLE}X Phoneの「通知アプリ」から確認できます。")
-        XphoneOs.playTritone(player)
+        XphoneModule.playTritone(player)
     }
 
     /**

--- a/src/main/java/work/xeltica/craft/core/xphone/apps/BedrockToolsApp.kt
+++ b/src/main/java/work/xeltica/craft/core/xphone/apps/BedrockToolsApp.kt
@@ -5,7 +5,7 @@ import org.bukkit.entity.Player
 import work.xeltica.craft.core.gui.Gui
 import work.xeltica.craft.core.gui.MenuItem
 import work.xeltica.craft.core.utils.BedrockDisclaimerUtil
-import work.xeltica.craft.core.xphone.XphoneOs
+import work.xeltica.craft.core.modules.xphone.XphoneModule
 
 /**
  * 統合版ユーザー向けツールを揃えたアプリ。
@@ -24,5 +24,5 @@ class BedrockToolsApp : AppBase() {
         ))
     }
 
-    override fun isVisible(player: Player) = XphoneOs.isBedrockPlayer(player)
+    override fun isVisible(player: Player) = XphoneModule.isBedrockPlayer(player)
 }

--- a/src/main/java/work/xeltica/craft/core/xphone/apps/VoteApp.kt
+++ b/src/main/java/work/xeltica/craft/core/xphone/apps/VoteApp.kt
@@ -2,7 +2,7 @@ package work.xeltica.craft.core.xphone.apps
 
 import org.bukkit.Material
 import org.bukkit.entity.Player
-import work.xeltica.craft.core.xphone.XphoneOs
+import work.xeltica.craft.core.modules.xphone.XphoneModule
 
 /**
  * サーバー投票アプリ
@@ -17,6 +17,6 @@ class VoteApp : AppBase() {
         player.performCommand("vote")
     }
 
-    override fun isVisible(player: Player): Boolean = !XphoneOs.isBedrockPlayer(player) &&  player.world.name != "event"
+    override fun isVisible(player: Player): Boolean = !XphoneModule.isBedrockPlayer(player) &&  player.world.name != "event"
 }
 


### PR DESCRIPTION
resolve #160 

## これまで
* 各機能の実装が、Command, Handler, XphoneApp, Store, Runnableにバラバラに定義されている
* それらをXCorePluginクラスで全て読み込む

## これから
* 各機能はモジュールという新概念にまとめられる
* Module内にロジックを書く
* Commandなどは、ModuleのonEnableフックで登録する
* XCorePlugin側でコマンドを管理していたが、CommandRegistryという新たなオブジェクトを追加し、それで管理する方針に

## 本リポジトリの対応

* モジュール化に必要なX-Core APIを整備した
  * work.xeltica.craft.core.api.ModuleBase
* コマンドの基底クラスを `work.xeltica.craft.core.api.commands` に移した
* X Phone関連機能のみをモジュール化した
  * その他の機能は今後、少しずつモジュールに移行していく方針（これは分業できたらしたい）