### PR TITLE
#220 修正

### DIFF
--- a/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
+++ b/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
@@ -51,7 +51,13 @@ class EbiPowerHandler : Listener {
     private val breakBonusList = HashSet<Material>()
 
     init {
-        crops.addAll(Tag.CROPS.values)
+        crops.add(Material.WHEAT)
+        crops.add(Material.CARROT)
+        crops.add(Material.POTATO)
+        crops.add(Material.BEETROOT)
+
+        breakBonusList.add(Material.PUMPKIN)
+        breakBonusList.add(Material.MELON)
 
         breakBonusList.addAll(Tag.BASE_STONE_OVERWORLD.values)
         breakBonusList.addAll(Tag.BASE_STONE_NETHER.values)

--- a/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
+++ b/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
@@ -170,8 +170,8 @@ class EbiPowerHandler : Listener {
         val p = e.player
         if (playerIsInBlacklisted(p)) return
         val blockData = e.block.blockData
-        HintModule.achieve(p, Hint.HARVEST_AND_EARN_MONEY)
         if (blockData is org.bukkit.block.data.Ageable && blockData.age == blockData.maximumAge) {
+            HintModule.achieve(p, Hint.HARVEST_AND_EARN_MONEY)
             val tool = p.inventory.itemInMainHand
             val bonus = getBlockDropBonus(tool)
             val power = (1 + bonus) * HARVEST_POWER_MULTIPLIER

--- a/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
+++ b/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
@@ -167,6 +167,7 @@ class EbiPowerHandler : Listener {
      */
     @EventHandler
     fun onHarvestCrops(e: BlockBreakEvent) {
+        if (!crops.contains(e.block.type)) return
         val p = e.player
         if (playerIsInBlacklisted(p)) return
         val blockData = e.block.blockData


### PR DESCRIPTION
fixes #220
# 変更点
- 対象でないブロックの破壊でもヒント「農家の一日」が達成されるバグの修正。
- カボチャ、スイカを「エビパワーマイニング」枠へ移動。
- カボチャの茎、スイカの茎を「農家の一日」枠から削除。

(「農家の一日」枠に残っているのは、成熟した小麦、人参、じゃが芋、ビートルート)
(上記修正により、これまでEPが貯まる対象になっていたと思われる、ココア豆等のAgeableなブロックでEPが貯まらなくなった)