### PR TITLE
#228(カカオ豆、ネザーウォートもEP入手対象にする)の修正

### DIFF
--- a/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
+++ b/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
@@ -55,6 +55,8 @@ class EbiPowerHandler : Listener {
         crops.add(Material.CARROT)
         crops.add(Material.POTATO)
         crops.add(Material.BEETROOT)
+        crops.add(Material.COCOA)
+        crops.add(Material.NETHER_WART)
 
         breakBonusList.add(Material.PUMPKIN)
         breakBonusList.add(Material.MELON)

--- a/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
+++ b/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
@@ -52,9 +52,9 @@ class EbiPowerHandler : Listener {
 
     init {
         crops.add(Material.WHEAT)
-        crops.add(Material.CARROT)
-        crops.add(Material.POTATO)
-        crops.add(Material.BEETROOT)
+        crops.add(Material.CARROTS)
+        crops.add(Material.POTATOES)
+        crops.add(Material.BEETROOTS)
         crops.add(Material.COCOA)
         crops.add(Material.NETHER_WART)
 


### PR DESCRIPTION
fixes #228 
- カカオ豆、ネザーウォートをEP対象に
- (人参、じゃが芋、ビートルートがミスでEP入らなくなっていたので修正)