### PR TITLE
FIx 239(共有ワールド、共有ネザー、共有エンド、資源エンドの場合はエビパワーを付与しないように)

### DIFF
--- a/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
+++ b/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
@@ -50,6 +50,8 @@ class EbiPowerHandler : Listener {
     private val crops = HashSet<Material>()
     private val breakBonusList = HashSet<Material>()
 
+    private val noEpByKillingWorlds = arrayOf("wildarea2", "wildarea2_nether", "wildarea2_the_end", "shigen_end")
+
     init {
         crops.add(Material.WHEAT)
         crops.add(Material.CARROTS)
@@ -147,8 +149,7 @@ class EbiPowerHandler : Listener {
         val killer = e.entity.killer ?: return
 
         //共有ワールド、共有ネザー、共有エンド、資源エンドの場合はエビパワーを付与しない
-        val prohibitedWorlds = arrayOf("wildarea2", "wildarea2_nether", "wildarea2_the_end", "shigen_end")
-        if (prohibitedWorlds.contains(killer.world.name)) return
+        if (noEpByKillingWorlds.contains(killer.world.name)) return
 
         if (playerIsInBlacklisted(killer)) return
         // don't kill cats

--- a/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
+++ b/src/main/java/work/xeltica/craft/core/modules/ebipower/EbiPowerHandler.kt
@@ -146,6 +146,10 @@ class EbiPowerHandler : Listener {
         val victim = e.entity
         val killer = e.entity.killer ?: return
 
+        //共有ワールド、共有ネザー、共有エンド、資源エンドの場合はエビパワーを付与しない
+        val prohibitedWorlds = arrayOf("wildarea2", "wildarea2_nether", "wildarea2_the_end", "shigen_end")
+        if (prohibitedWorlds.contains(killer.world.name)) return
+
         if (playerIsInBlacklisted(killer)) return
         // don't kill cats
         if (victim is Cat || victim is Ocelot) return


### PR DESCRIPTION
fixes #239 
共有ワールド、共有ネザー、共有エンド、資源エンドの場合はエビパワーを付与しないように